### PR TITLE
fix MinGW compile error

### DIFF
--- a/SeetaNet/src/orz/tools/box.cpp
+++ b/SeetaNet/src/orz/tools/box.cpp
@@ -130,7 +130,7 @@ std::vector<std::pair<size_t, size_t>> lsplit_bins(size_t first, size_t second, 
 static struct tm time2tm(std::time_t from)
 {
     std::tm to = {0};
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     localtime_s(&to, &from);
 #else
     localtime_r(&from, &to);


### PR DESCRIPTION
MinGW does not have the _MSC_VER macro .
```
SeetaFace2/SeetaNet/src/orz/tools/box.cpp:136:5: error: 'localtime_r' was not declared in this scope; did you mean 'localtime_s'?
  136 |     localtime_r(&from, &to);
      |     ^~~~~~~~~~~
```